### PR TITLE
Added WayScript's NewRelic integration quickstart link

### DIFF
--- a/managing-tools/integrations/new-relic.md
+++ b/managing-tools/integrations/new-relic.md
@@ -1,6 +1,6 @@
 # New Relic
 
-WayScript's NewRelic integration allows you to connect to your NewRelic account and set up default monitoring across your workspace's Lairs. You’ll get automatic visibility into the health of all pre-production, staging, and production environments via New Relic.
+WayScript's [NewRelic integration](https://newrelic.com/instant-observability/wayscript/51294fb4-6b0a-4ee5-acad-c377b3b528d5) allows you to connect to your NewRelic account and set up default monitoring across your workspace's Lairs. You’ll get automatic visibility into the health of all pre-production, staging, and production environments via New Relic.
 
 Adding the integration with enable two monitoring capabilities in your workspace Lairs:
 


### PR DESCRIPTION
Hey WayScript dev team,

We have many users on our platform who are using WayScript and would like to instrument it. We’d love to provide a smooth experience for WayScript users who need to use commercial monitoring solutions, such as New Relic. Please see our documentation [here](https://newrelic.com/instant-observability/wayscript/51294fb4-6b0a-4ee5-acad-c377b3b528d5).

Please consider adding a link for your direct users to provide an option for New Relic.  For your convenience, we have submitted this PR with our proposed content.

Please feel free to let us know if you have any questions or concerns.

Thank you for your consideration.
