### PR TITLE
Added youtube lmage link for core features section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ With WayScript, you can unblock data access by quickly turning database queries 
 
 #### Overview of WayScript's core features
 
-{% embed url="https://www.youtube.com/watch?t=177s&v=clxsmgd4g5Y" %}
+[![What is WayScript X](https://user-images.githubusercontent.com/101400043/210129803-e2e35f80-403a-4bbb-8f3c-aa0d3bd5c31f.JPG)](https://www.youtube.com/watch?t=177s&v=clxsmgd4g5Y)


### PR DESCRIPTION
The youtube link was broken before for README.md file , now it is more user friendly to click on intended behavior of that video link. 

Now : 
![image](https://user-images.githubusercontent.com/101400043/210129978-0ddf015a-8004-474c-a110-3c04f3b33396.png)
